### PR TITLE
Fixed V13 FragmentStatePagerAdapter which was deprecated

### DIFF
--- a/com.vogella.android.inlineprogressreporting/src/com/example/android/animationsdemo/ScreenSlideActivity.java
+++ b/com.vogella.android.inlineprogressreporting/src/com/example/android/animationsdemo/ScreenSlideActivity.java
@@ -20,7 +20,7 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.NavUtils;
 import android.support.v4.view.PagerAdapter;


### PR DESCRIPTION
android.support.v13.app.FragmentStatePagerAdapter was deprecated in API level 27.1.0. Changed this to android.support.v4.app.FragmentStatePagerAdapter